### PR TITLE
Restore interface compatibility

### DIFF
--- a/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/AttributeDriver.php
@@ -21,7 +21,6 @@ use function constant;
 use function count;
 use function defined;
 use function get_class;
-use function is_array;
 
 class AttributeDriver extends AnnotationDriver
 {
@@ -48,7 +47,7 @@ class AttributeDriver extends AnnotationDriver
         $classAnnotations = $this->reader->getClassAnnotations(new ReflectionClass($className));
 
         foreach ($classAnnotations as $a) {
-            $annot = is_array($a) ? $a[0] : $a;
+            $annot = $a instanceof RepeatableAttributeCollection ? $a[0] : $a;
             if (isset($this->entityAnnotationClasses[get_class($annot)])) {
                 return false;
             }

--- a/lib/Doctrine/ORM/Mapping/Driver/RepeatableAttributeCollection.php
+++ b/lib/Doctrine/ORM/Mapping/Driver/RepeatableAttributeCollection.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\ORM\Mapping\Driver;
+
+use ArrayObject;
+use Doctrine\ORM\Mapping\Annotation;
+
+/**
+ * @template-extends ArrayObject<int,Annotation>
+ */
+final class RepeatableAttributeCollection extends ArrayObject
+{
+}

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1218,10 +1218,6 @@
     <DocblockTypeContradiction occurrences="1">
       <code>$class</code>
     </DocblockTypeContradiction>
-    <LessSpecificReturnStatement occurrences="1">
-      <code>$mapping</code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="1"/>
     <NoInterfaceProperties occurrences="5">
       <code>$metadata-&gt;inheritanceType</code>
       <code>$metadata-&gt;isEmbeddedClass</code>
@@ -1289,10 +1285,6 @@
       <code>$value[1]</code>
     </InvalidArrayAccess>
     <InvalidScalarArgument occurrences="1"/>
-    <LessSpecificReturnStatement occurrences="1">
-      <code>$mapping</code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="1"/>
     <NonInvariantDocblockPropertyType occurrences="1">
       <code>$entityAnnotationClasses</code>
     </NonInvariantDocblockPropertyType>
@@ -1324,12 +1316,6 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$attributeClassName</code>
     </ArgumentTypeCoercion>
-    <InvalidReturnStatement occurrences="1">
-      <code>$instances</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
-      <code>array&lt;Annotation&gt;</code>
-    </InvalidReturnType>
     <MissingParamType occurrences="3">
       <code>$annotationName</code>
       <code>$annotationName</code>

--- a/psalm.xml
+++ b/psalm.xml
@@ -21,5 +21,11 @@
                 <file name="lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php"/>
             </errorLevel>
         </ParadoxicalCondition>
+        <NullArgument>
+            <errorLevel type="suppress">
+                <!-- See https://github.com/vimeo/psalm/issues/5920 -->
+                <file name="lib/Doctrine/ORM/Mapping/Driver/AttributeReader.php"/>
+            </errorLevel>
+        </NullArgument>
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
A reader is supposed to only ever return objects. By introducing
RepeatableAttributeCollection, we fulfill the interface and improve
clarity.
